### PR TITLE
Feature/main  로그인 유무에 따른 헤더 변경 수정

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,12 +1,12 @@
 import { Outlet } from 'react-router-dom';
+
 import Header from './components/shared/Header';
-import { AuthContextProvider } from './context/AuthContext';
 
 export default function App() {
   return (
-    <AuthContextProvider>
+    <>
       <Header />
       <Outlet />
-    </AuthContextProvider>
+    </>
   );
 }

--- a/src/components/main/FeatureComparison.jsx
+++ b/src/components/main/FeatureComparison.jsx
@@ -1,7 +1,8 @@
 import { useNavigate } from 'react-router-dom';
+
 import Button from '../shared/Button';
-import styles from './FeatureComparison.module.scss';
 import { useAuthContext } from '../../context/AuthContext';
+import styles from './FeatureComparison.module.scss';
 
 export default function FeatureComparison() {
   const { user } = useAuthContext();
@@ -34,7 +35,7 @@ export default function FeatureComparison() {
       </tr>
       <tr>
         <td className={styles.td_border_right}>
-          WonderBox 어드벤트 캘린더 생성
+          Wonder Box 어드벤트 캘린더 생성
         </td>
         <td>무제한</td>
       </tr>
@@ -53,7 +54,7 @@ export default function FeatureComparison() {
       </tr>
       <tr>
         <th>
-          Asesome Wonder Box - <span>For free</span> / 회원가입 필요
+          Awesome Wonder Box - <span>For free</span> / 회원가입 필요
         </th>
         <th>
           <Button onClick={handleAwesomClick}>
@@ -62,7 +63,7 @@ export default function FeatureComparison() {
         </th>
       </tr>
       <tr>
-        <td colSpan={2}>+ simple WonderBox의 모든 기능</td>
+        <td colSpan={2}>+ Simple Wonder Box의 모든 기능</td>
       </tr>
       <tr>
         <td className={styles.td_border_right}>업로드 가능한 미디어</td>
@@ -72,7 +73,7 @@ export default function FeatureComparison() {
       </tr>
       <tr>
         <td colSpan={2}>
-          완성된 WonderBox 캘린더 <strong>저장</strong>, 완성 후{' '}
+          완성된 Wonder Box 캘린더 <strong>저장</strong>, 완성 후{' '}
           <strong>수정</strong>
         </td>
       </tr>

--- a/src/components/main/WonderBoxInfo.jsx
+++ b/src/components/main/WonderBoxInfo.jsx
@@ -1,4 +1,5 @@
 import { useNavigate } from 'react-router-dom';
+
 import Button from '../shared/Button';
 import styles from './WonderBoxInfo.module.scss';
 
@@ -22,7 +23,7 @@ export default function WonderBoxInfo() {
           </div>
         </div>
         <div>
-          사진, 동영상, 메세지를 업로드해서 나만의 어드밴트 캘린더를 만들어
+          사진, 동영상, 메세지를 업로드해서 나만의 어드벤트 캘린더를 만들어
           소중한 사람들에게 공유하세요!
         </div>
       </div>
@@ -33,7 +34,8 @@ export default function WonderBoxInfo() {
             Simple Wonder Box - For free
           </Button>
         </div>
-        회원가입 유무에 따라 Awesome WonderBox의 모든 기능을 이용하실 수 있어요!
+        회원가입 유무에 따라 Awesome Wonder Box의 모든 기능을 이용하실 수
+        있어요!
       </div>
     </>
   );

--- a/src/components/shared/Header.jsx
+++ b/src/components/shared/Header.jsx
@@ -5,41 +5,35 @@ import styles from './Header.module.scss';
 import { useAuthContext } from '../../context/AuthContext';
 
 export default function Header() {
-  const { user, login, logout } = useAuthContext();
-  const navigate = useNavigate();
+  const { user, logout } = useAuthContext();
+  const nevigate = useNavigate();
 
-  const handleClick = () => {
-    if (user) {
-      logout();
-      navigate('/');
-      return;
-    }
-
-    login();
+  const handleLogoutClick = () => {
+    logout();
+    nevigate('/');
   };
 
-  const handleSignupClick = () => {
-    navigate('/signup');
-  };
-
-  const handleMyWonderBoxClick = () => {
-    navigate('/calendars/:calendarId/share');
-  };
   return (
     <div className={styles.header}>
       <Link to="/" className={styles.logo}>
         WonderBox
       </Link>
       <div className={styles.buttons}>
-        <Button className={styles.button} onClick={handleClick}>
-          {user ? '로그아웃' : ' 로그인'}
-        </Button>
+        {user ? (
+          <Button className={styles.button} onClick={handleLogoutClick}>
+            로그아웃
+          </Button>
+        ) : (
+          <Button className={styles.button} to="/login">
+            로그인
+          </Button>
+        )}
         {!user ? (
-          <Button className={styles.button} onClick={handleSignupClick}>
+          <Button className={styles.button} to="/signup">
             회원가입
           </Button>
         ) : (
-          <Button className={styles.button} onClick={handleMyWonderBoxClick}>
+          <Button className={styles.button} to="/calendars">
             My Wonderbox
           </Button>
         )}

--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -5,12 +5,14 @@ const AuthContext = createContext();
 export function AuthContextProvider({ children }) {
   const [user, setUser] = useState(false);
 
-  const login = () => {
+  const login = async () => {
     setUser(true);
   };
 
-  const logout = () => {
+  const logout = async () => {
     setUser(false);
+    localStorage.removeItem('accessToken');
+    localStorage.removeItem('refreshToken');
   };
 
   return (

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -14,6 +14,7 @@ import DailyBoxesForm from './pages/DailyBoxesForm';
 import StyleForm from './pages/StyleForm';
 import Preview from './pages/Preview';
 import SharedCalendar from './pages/SharedCalendar';
+import { AuthContextProvider } from './context/AuthContext';
 
 import './index.scss';
 import './style.scss';
@@ -45,6 +46,8 @@ const router = createBrowserRouter([
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
-    <RouterProvider router={router} />
+    <AuthContextProvider>
+      <RouterProvider router={router} />
+    </AuthContextProvider>
   </React.StrictMode>,
 );

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -1,15 +1,18 @@
 import { Link, useNavigate } from 'react-router-dom';
 import { useState } from 'react';
+import { FiMail, FiKey } from 'react-icons/fi';
+
 import Button from '../components/shared/Button';
 import styles from './Login.module.scss';
-import { FiMail, FiKey } from 'react-icons/fi';
 import Loading from '../components/shared/Loading';
+import { useAuthContext } from '../context/AuthContext';
 
 export default function Login() {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState(null);
+  const { login } = useAuthContext();
 
   const navigate = useNavigate();
 
@@ -36,6 +39,7 @@ export default function Login() {
       setIsLoading(false);
 
       localStorage.setItem('jwt', data.accessToken);
+      login();
       navigate('/');
     } catch (error) {
       setIsLoading(false);
@@ -79,7 +83,7 @@ export default function Login() {
 
         <Button type="submit">로그인</Button>
       </form>
-      <div className={styles.divider}></div>
+      <div className={styles.divider} />
       <div className={styles.link__block}>
         <p>아직 회원이 아니신가요?</p>
         <Link to="/signup">가입하고 Awesome WonderBox 만들러가기</Link>

--- a/src/pages/Signup.jsx
+++ b/src/pages/Signup.jsx
@@ -1,9 +1,10 @@
 import { Link, useNavigate } from 'react-router-dom';
 import { useState } from 'react';
+import { FiMail, FiKey, FiCheck } from 'react-icons/fi';
 import Button from '../components/shared/Button';
 import styles from './Signup.module.scss';
-import { FiMail, FiKey, FiCheck } from 'react-icons/fi';
 import Loading from '../components/shared/Loading';
+import { useAuthContext } from '../context/AuthContext';
 
 export default function Signup() {
   const [email, setEmail] = useState('');
@@ -14,6 +15,7 @@ export default function Signup() {
   const [emailError, setEmailError] = useState('');
   const [passwordError, setPasswordError] = useState('');
   const [passwordConfirmError, setPasswordConfirmError] = useState('');
+  const { login } = useAuthContext();
 
   const navigate = useNavigate();
 
@@ -111,6 +113,7 @@ export default function Signup() {
       setIsLoading(false);
 
       localStorage.setItem('accessToken', data.accessToken);
+      login();
       navigate('/custom/base-info');
     } catch (error) {
       setIsLoading(false);
@@ -174,7 +177,7 @@ export default function Signup() {
 
         <Button type="submit">회원가입</Button>
       </form>
-      <div className={styles.divider}></div>
+      <div className={styles.divider} />
       <div className={styles.link__block}>
         <p>이미 가입하셨나요?</p>
         <Link to="/login">Awesome WonderBox 만들러가기</Link>


### PR DESCRIPTION
## PR 목적
로그인 유무에 따라서 헤더가 변경될 수 있도록 수정했습니다. 

## 작업 내용
- 기존에는 App.jsx에 AuthContextProvider를 사용했지만 index.jsx로 변경
- 로그인 클릭 시 페이지 이동이 안되었는데 로그인 페이지로 이동가능하게 수정
- 로그인 후 메인 페이지로 이동하면 로그아웃 과 My WonderBox 버튼으로 변경 완료
- 로그인 후 Awesome WonderBox 버튼 클릭 시 기본정보 입력 페이지로 이동
  -   로그인을 하지 않으면 회원가입 페이지로 이동하는 것 확인
- My WonderBox 경로 변경

## 주의 사항
