### PR TITLE
Feature/base-info localStorage id reset 기능 수정, 기간설정 에러메세지 오류 수정

### DIFF
--- a/src/errors/validateInput.js
+++ b/src/errors/validateInput.js
@@ -2,6 +2,17 @@ import { isDateValid } from '../utils/date';
 import ERRORS from './errorMessage';
 
 export function validateInput(name, value, formData) {
+  let newFormData = { ...formData, [name]: value };
+
+  if (name === 'startDate' || name === 'endDate') {
+    if (!newFormData.startDate || !newFormData.endDate) {
+      return ERRORS.CALENDAR.INVALID.DURATION;
+    }
+    if (!isDateValid(newFormData.startDate, newFormData.endDate)) {
+      return ERRORS.CALENDAR.INVALID.MIN_DURATION;
+    }
+  }
+
   switch (name) {
     case 'title':
       if (!value) return ERRORS.CALENDAR.INVALID.TITLE;
@@ -9,15 +20,6 @@ export function validateInput(name, value, formData) {
       return '';
     case 'creator':
       if (!value) return ERRORS.CALENDAR.INVALID.CREATOR;
-      return '';
-    case 'startDate':
-    case 'endDate':
-      if (!formData.startDate || !formData.endDate) {
-        return ERRORS.CALENDAR.INVALID.DURATION;
-      }
-      if (!isDateValid(formData.startDate, formData.endDate)) {
-        return ERRORS.CALENDAR.INVALID.MIN_DURATION;
-      }
       return '';
     case 'options':
       if (!value) return ERRORS.CALENDAR.INVALID.OPTION;

--- a/src/hooks/useFormInput.jsx
+++ b/src/hooks/useFormInput.jsx
@@ -14,6 +14,8 @@ export default function useFormInput(initialValues) {
       [name]: value,
     }));
 
+    const error = validateInput(name, value, { ...formData, [name]: value });
+
     if (name === 'startDate' || name === 'endDate') {
       setFormErrors((prevFormErrors) => ({
         ...prevFormErrors,
@@ -21,8 +23,6 @@ export default function useFormInput(initialValues) {
         endDate: '',
       }));
     }
-
-    const error = validateInput(name, value, { ...formData, [name]: value });
 
     setFormErrors((prevFormErrors) => ({
       ...prevFormErrors,

--- a/src/hooks/useFormInput.jsx
+++ b/src/hooks/useFormInput.jsx
@@ -14,7 +14,15 @@ export default function useFormInput(initialValues) {
       [name]: value,
     }));
 
-    const error = validateInput(name, value, formData);
+    if (name === 'startDate' || name === 'endDate') {
+      setFormErrors((prevFormErrors) => ({
+        ...prevFormErrors,
+        startDate: '',
+        endDate: '',
+      }));
+    }
+
+    const error = validateInput(name, value, { ...formData, [name]: value });
 
     setFormErrors((prevFormErrors) => ({
       ...prevFormErrors,
@@ -35,6 +43,7 @@ export default function useFormInput(initialValues) {
     });
 
     setFormErrors(newErrors);
+
     return isValid;
   }
 

--- a/src/pages/BaseInfoForm.jsx
+++ b/src/pages/BaseInfoForm.jsx
@@ -47,9 +47,7 @@ export default function BaseInfoForm() {
       return;
     }
 
-    const createdAt = new Date();
-
-    const payload = { title, creator, createdAt, startDate, endDate, options };
+    const payload = { title, creator, startDate, endDate, options };
 
     try {
       if (user) {
@@ -80,14 +78,13 @@ export default function BaseInfoForm() {
         payload.calendarId = localCalendarId;
 
         if (!calendarId) {
-          if (!localStorage.getItem('idList')) {
-            localStorage.setItem('idList', JSON.stringify([]));
+          const existingId = localStorage.getItem('id');
+
+          if (existingId) {
+            localStorage.removeItem(existingId);
           }
 
-          const idList = JSON.parse(localStorage.getItem('idList'));
-
-          idList.push(localCalendarId);
-          localStorage.setItem('idList', JSON.stringify(idList));
+          localStorage.setItem('id', localCalendarId);
         }
 
         const localData = JSON.stringify(payload);
@@ -130,8 +127,7 @@ export default function BaseInfoForm() {
     }
 
     function getLocalBaseInfo(calendarId) {
-      const idList = JSON.parse(localStorage.getItem('idList'));
-      const localCalendarId = idList[idList.length - 1].toString();
+      const localCalendarId = localStorage.getItem('id');
 
       if (localCalendarId !== calendarId) {
         redirectErrorPage(navigate, undefined, ERRORS.AUTH.UNAUTHORIZED, 401);


### PR DESCRIPTION
## PR 목적

 localStorage id reset 기능 수정, 기간설정 에러메세지 오류 수정

## 작업 내용

- localStorage idList에 id 무한 추가되는 것 reset 기능 추가
   -> id 하나로 유지 되기때문에 idList에서 id로 변경

- 리팩토링 후 기간 설정 에러메세지 사라지지 않는 오류 수정

## 주의 사항
