### PR TITLE
Feature/local-save 비인증 유저 로그인시 DB로 데이터 보내기 

### DIFF
--- a/src/components/shareBox/ShareBox.jsx
+++ b/src/components/shareBox/ShareBox.jsx
@@ -135,7 +135,13 @@ export default function ShareBox({ content, index, date, box, options }) {
         onClick={handleClickBox}
       >
         {isOpen ? (
-          <div className={styles.shareBox__content}>
+          <div
+            className={
+              formData.text
+                ? styles.shareBox__content
+                : styles.shareBox__content__media
+            }
+          >
             {hasImage ? (
               <img src={previewImage} alt="이미지 미리보기" />
             ) : hasVideo ? (

--- a/src/components/shareBox/ShareBox.module.scss
+++ b/src/components/shareBox/ShareBox.module.scss
@@ -13,6 +13,24 @@
     cursor: pointer;
   }
 
+  .shareBox__content__media {
+    position: relative;
+    width: 100%;
+    height: 100%;
+    border-radius: 0 0 10px 10px;
+    overflow: hidden;
+
+    img,
+    video,
+    audio {
+      display: block;
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+      border-radius: 0 0 10px 10px;
+    }
+  }
+
   .shareBox__content {
     position: relative;
     width: 100%;

--- a/src/pages/DailyBoxesForm.jsx
+++ b/src/pages/DailyBoxesForm.jsx
@@ -13,7 +13,6 @@ import { redirectErrorPage } from '../errors/handleError';
 import ERRORS from '../errors/errorMessage';
 import styles from './DailyBoxesForm.module.scss';
 
-
 export default function DailyBoxesForm() {
   const { calendarId } = useParams();
   const { user } = useAuthContext();
@@ -65,6 +64,7 @@ export default function DailyBoxesForm() {
           endDate: dailyBoxes[dailyBoxes.length - 1].date,
           dailyBoxes,
         });
+
         setIsLoading(false);
       } catch (error) {
         redirectErrorPage(navigate, error);
@@ -122,7 +122,7 @@ export default function DailyBoxesForm() {
       </div>
       {isOpen && (
         <Modal isOpen={isOpen} className={styles.modal__notice}>
-          <p>아무것도 입력하지 않은 날짜에는 임의의 사진이 보여집니다.</p>
+          <p>아무것도 입력하지 않은 날짜에는 빈 칸이 보여집니다.</p>
           <p>그래도 저장하시겠습니까?</p>
           <div className={styles.button__block}>
             <Link to={`/custom/style/${calendarId}`} className={styles.moveBtn}>

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -39,7 +39,7 @@ export default function Login() {
       setIsLoading(false);
 
       login(data.accessToken);
-      navigate('/');
+      navigate('/custom/base-info');
     } catch (error) {
       setIsLoading(false);
       setError(

--- a/src/pages/StyleForm.jsx
+++ b/src/pages/StyleForm.jsx
@@ -34,6 +34,9 @@ export default function StyleForm() {
 
   const { user } = useAuthContext();
   const { calendarId } = useParams();
+
+  const localCalendarId = localStorage.getItem('id');
+
   const { fetchData, isLoading, setIsLoading, navigate, error } =
     useFetchData();
 
@@ -96,6 +99,11 @@ export default function StyleForm() {
 
         updateFormData({ sharedUrl: data.sharedUrl });
 
+        if (localCalendarId) {
+          localStorage.removeItem(localCalendarId);
+          localStorage.removeItem('id');
+        }
+
         setIsOpen(true);
       }
 
@@ -113,7 +121,6 @@ export default function StyleForm() {
           },
         };
 
-        const localCalendarId = JSON.parse(localStorage.getItem('id'));
         const localCalendar = JSON.parse(localStorage.getItem(localCalendarId));
 
         setIsLoading(true);
@@ -153,7 +160,6 @@ export default function StyleForm() {
             image,
             box,
           } = data.style;
-
           setPreviewImage(image);
 
           updateFormData({
@@ -169,43 +175,19 @@ export default function StyleForm() {
 
           setExistingStyleData(true);
         }
+        if (localCalendarId) {
+          getLocalData();
+        }
       } catch (error) {
         redirectErrorPage(navigate, error);
       }
     }
 
     function getLocalStyle(calendarId) {
-      const localCalendarId = localStorage.getItem('id');
-
       if (localCalendarId !== calendarId) {
         redirectErrorPage(navigate, undefined, ERRORS.AUTH.UNAUTHORIZED, 401);
       }
-
-      const localCalendar = JSON.parse(localStorage.getItem(localCalendarId));
-
-      if (localCalendar && localCalendar.style) {
-        const { titleFont, titleColor, borderColor, backgroundColor, image } =
-          localCalendar.style;
-
-        const { font, color, bgColor } = localCalendar.style.box;
-
-        if (image) {
-          setPreviewImage(image);
-        } else {
-          setPreviewImage('');
-        }
-
-        updateFormData({
-          titleFont,
-          titleColor,
-          borderColor,
-          backgroundColor,
-          image,
-          font,
-          color,
-          bgColor,
-        });
-      }
+      getLocalData();
     }
 
     if (user) {
@@ -215,16 +197,37 @@ export default function StyleForm() {
     }
   }, [calendarId, user]);
 
-
-  function handleClose() {
-    setIsStyleValid(true);
-    setIsOpen(false);
-  }
-
   function handleCopyClipBoard(text) {
     navigator.clipboard.writeText(text);
   }
 
+  function getLocalData() {
+    const localCalendar = JSON.parse(localStorage.getItem(localCalendarId));
+
+    if (localCalendar && localCalendar.style) {
+      const { titleFont, titleColor, borderColor, backgroundColor, image } =
+        localCalendar.style;
+
+      const { font, color, bgColor } = localCalendar.style.box;
+
+      if (image) {
+        setPreviewImage(image);
+      } else {
+        setPreviewImage('');
+      }
+
+      updateFormData({
+        titleFont,
+        titleColor,
+        borderColor,
+        backgroundColor,
+        image,
+        font,
+        color,
+        bgColor,
+      });
+    }
+  }
 
   return (
     <div className={styles.container}>


### PR DESCRIPTION
## PR 목적
비인증 유저가 로그인 후 기존에 작성했던 데이터를 DB로 보내도록 수정

## 작업 내용
- 기본정보 페이지에서 로컬스토리지에 있는 기본정보 데이터, 데일리박스 데이터를 POST하면 DB에 저장
- 스타일 페이지에서 로컬스토리지에 저장했던 내용을 불러오고 POST시 DB에 저장
- 데일리박스 저장 문구 변경
- 공유 페이지에서 메세지가 없는 경우 미디어로 가득 보이게 수정
- 로그인 시 기본정보 페이지로 이동되게 수정

## 주의 사항
